### PR TITLE
Examples for how to store multi-selects

### DIFF
--- a/project/src/main/java/com/google/sps/servlets/Resource.java
+++ b/project/src/main/java/com/google/sps/servlets/Resource.java
@@ -1,5 +1,8 @@
 package com.google.sps.servlets;
 
+import javax.imageio.plugins.tiff.ExifInteroperabilityTagSet;
+
+
 public final class Resource {
     private final long id;
     private final long timestamp;
@@ -13,6 +16,14 @@ public final class Resource {
     private final String ageGroup;
     private final String ethnicity;
 
+    // Example of turning comma-delimited string into a list.
+    // This is stored in a separate field so changing the type from String to [] does not
+    // crash the front end.
+    private final String[] ageGroupList;
+
+    // Example of storing array from native array field in Datastore
+    private String[] colors;
+
     public Resource(long id, long timestamp, String organizerName, String organizerEmail, String eventName, String eventDate, String location, String link, String description, String ageGroup, String ethnicity) {
         this.id = id;
         this.timestamp = timestamp;
@@ -25,5 +36,11 @@ public final class Resource {
         this.link = link;
         this.description = description;
         this.ethnicity = ethnicity;
+
+        this.ageGroupList =  ageGroup.split(",");
+    }
+
+    public void setColors(String[] colors) {
+        this.colors = colors;
     }
 }

--- a/project/src/main/java/com/google/sps/servlets/ResourceHandlerServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/ResourceHandlerServlet.java
@@ -7,6 +7,10 @@ import com.google.cloud.datastore.FullEntity;
 import com.google.cloud.datastore.KeyFactory;
 import com.google.cloud.datastore.Value;
 
+import com.google.cloud.datastore.ListValue;
+import java.util.stream.Collectors;
+import java.util.Objects;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
@@ -18,10 +22,25 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/resource-handler")
 public class ResourceHandlerServlet extends HttpServlet {
 
+    private static final List<String> ageGroupOptions = new ArrayList<>(Arrays.asList(
+            "ageGroup-1",
+            "ageGroup-2",
+            "ageGroup-3",
+            "ageGroup-4",
+            "ageGroup-5",
+            "ageGroup-6",
+            "ageGroup-7",
+            "ageGroup-8",
+            "ageGroup-9"));
+
+    private static final List<String> enthnicityOptions = new ArrayList<>(Arrays.asList(
+            // do the same for enthnicity
+            "enthnicity-1"));
+
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         // Get the values entered by the user
-        long timestamp = System.currentTimeMillis();
+
         String organizerName = request.getParameter("inputName");
         String organizerEmail = request.getParameter("inputEmail");
         String eventName = request.getParameter("inputEventName");
@@ -29,80 +48,23 @@ public class ResourceHandlerServlet extends HttpServlet {
         String location = request.getParameter("inputEventLocation");
         String link = request.getParameter("inputLink");
         String description = request.getParameter("inputDesciption");
-        String ageGroup = request.getParameter("ageGroup");
-        String ethnicity = request.getParameter("ethnicity");
 
-        // Create array for age groups
-        // List<String> ageGroup = new ArrayList<>();
+        // Hack to store a list as a comma-delimited string
+        String ageGroups = ageGroupOptions.stream()
+                .map(request::getParameter)
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining(","));
 
-        // if (request.getParameter("gradeNine") != null) {
-        //     ageGroup.add("Grade 9");
-        // }
-        // if (request.getParameter("gradeTen") != null) {
-        //     ageGroup.add("Grade 10");
-        // }
-        // if (request.getParameter("gradeEleven") != null) {
-        //     ageGroup.add("Grade 11");
-        // }
-        // if (request.getParameter("gradeTwelve") != null) {
-        //     ageGroup.add("Grade 12");
-        // }
-        // if (request.getParameter("freshman") != null) {
-        //     ageGroup.add("Freshman");
-        // }
-        // if (request.getParameter("sophomore") != null) {
-        //     ageGroup.add("Sophomore");
-        // }
-        // if (request.getParameter("junior") != null) {
-        //     ageGroup.add("Junior");
-        // }
-        // if (request.getParameter("senior") != null) {
-        //     ageGroup.add("Senior");
-        // }
-        
-        // Create array for ethnicities
-        // List<String> ethnicities = new ArrayList<>();
-
-        // if (request.getParameter("white") != null) {
-        //     ethnicities.add("White");
-        // }
-        // if (request.getParameter("black") != null) {
-        //     ethnicities.add("Black");
-        // }
-        // if (request.getParameter("hispanic") != null) {
-        //     ethnicities.add("Hispanic");
-        // }
-        // if (request.getParameter("asian") != null) {
-        //     ethnicities.add("Asian");
-        // }
-        // if (request.getParameter("americanIndian") != null) {
-        //     ethnicities.add("American Indian or Alaska Native");
-        // }
-        // if (request.getParameter("middleEastern") != null) {
-        //     ethnicities.add("Middle Eastern");
-        // }
-        // if (request.getParameter("twoOrMore") != null) {
-        //     ethnicities.add("2 or more");
-        // }
-        // if (request.getParameter("notToAnswer") != null) {
-        //     ethnicities.add("Prefer not to answer");
-        // }
-
-        // Print the value so you can see it in the server logs.
-        System.out.println("You submitted: " + organizerName);
-        System.out.println("You submitted: " + organizerEmail);
-        System.out.println("You submitted: " + eventName);
-        System.out.println("You submitted: " + eventDate);
-        System.out.println("You submitted: " + location);
-        System.out.println("You submitted: " + link);
-        System.out.println("You submitted: " + description);
+        String ethnicities = enthnicityOptions.stream()
+                .map(request::getParameter)
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining(","));
 
         // Datastore code
         Datastore datastore = DatastoreOptions.getDefaultInstance().getService();
         KeyFactory keyFactory = datastore.newKeyFactory().setKind("Resource");
-        FullEntity taskEntity =
-                Entity.newBuilder(keyFactory.newKey())
-                .set("timestamp", timestamp)
+        FullEntity taskEntity = Entity.newBuilder(keyFactory.newKey())
+                .set("timestamp", System.currentTimeMillis())
                 .set("organizerName", organizerName)
                 .set("organizerEmail", organizerEmail)
                 .set("eventName", eventName)
@@ -110,30 +72,25 @@ public class ResourceHandlerServlet extends HttpServlet {
                 .set("location", location)
                 .set("link", link)
                 .set("description", description)
-                .set("ageGroup", ageGroup)
-                .set("ethnicity", ethnicity)
+                // Example of how to store a list as type String
+                .set("ageGroup", ageGroups)
+                .set("ethnicity", ethnicities)
+                // Documentation
+                // https://cloud.google.com/datastore/docs/samples/datastore-array-value#datastore_array_value-java
+                // https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/com.google.cloud.datastore.ListValue#com_google_cloud_datastore_ListValue_newBuilder__
+                // To pass in a single list, per the documentation we must create one of type List<Value> 
+                // Example of how to create a true array in Datastore
+                .set("colors", ListValue.of("red", "blue"))
                 .build();
         datastore.put(taskEntity);
         response.sendRedirect("/view-events.html");
+    }
 
-        // Write the value to the response so the user can see it
-        // response.setContentType("text/html;");
-        // response.getWriter().println("Organizer name: " + organizerName);
-        // response.getWriter().println("Organizer email: " + organizerEmail);
-        // response.getWriter().println("Event name: " + eventName);
-        // response.getWriter().println("Event date: " + eventDate);
-        // response.getWriter().println("Location: " + location);
-        // response.getWriter().println("Link: " + link);
-        // response.getWriter().println("Description: " + description);
-
-        // response.getWriter().println("ageGroup count: " + ageGroup.size());
-        // response.getWriter().println("ethnicities count: " + ethnicities.size());
-
-        // for (int i = 0; i < ageGroup.size(); i++) {
-        //     response.getWriter().println("AgeGroup: " + ageGroup.get(i));
-        // }
-        // for (int i = 0; i < ethnicities.size(); i++) {
-        //     response.getWriter().println("Ethnicity: " + ethnicities.get(i));
-        // }
+    /**
+     * Retrieves the value of the provided parameter name if it exists; otherwise
+     * returns an empty String
+     */
+    private static String getOrDefault(HttpServletRequest request, String parameterName) {
+        return "";
     }
 }

--- a/project/src/main/java/com/google/sps/servlets/ResourceListServlet.java
+++ b/project/src/main/java/com/google/sps/servlets/ResourceListServlet.java
@@ -42,7 +42,17 @@ public class ResourceListServlet extends HttpServlet {
             String ageGroup = entity.getString("ageGroup");
             String ethnicities = entity.getString("ethnicity");
 
-            Resource resource = new Resource(id, timestamp, organizerName, organizerEmail, eventName, eventDate, location, link, description, ageGroup, ethnicities);
+            Resource resource = new Resource(id, timestamp, organizerName, organizerEmail, eventName, eventDate,
+                    location, link, description, ageGroup, ethnicities);
+
+            // Example, how to handle a native array. Documentation:
+            // https://cloud.google.com/java/docs/reference/google-cloud-datastore/latest/com.google.cloud.datastore.Entity
+            if (entity.contains("colors")) {
+                // TBD: Translate from List<Value> to List<String> ; casting does not work.
+                // List<String> colors = (List<String>)entity.getList("colors");
+                // resource.setColors(colors.toArray());
+            }
+
             formResponses.add(resource);
         }
         Gson gson = new Gson();

--- a/project/src/main/webapp/add-event.html
+++ b/project/src/main/webapp/add-event.html
@@ -72,47 +72,47 @@
                     <label for="inputAge">Target Age</label>
                 </div>
                 <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="ageGroup" id="inlineCheckbox1"
+                    <input class="form-check-input" type="radio" name="ageGroup-1" id="inlineCheckbox1"
                         value="Grade 9">
                     <label class="form-check-label" for="inlineCheckbox1">Grade 9</label>
                 </div>
                 <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="ageGroup" id="inlineCheckbox2"
+                    <input class="form-check-input" type="radio" name="ageGroup-2" id="inlineCheckbox2"
                         value="Grade 10">
                     <label class="form-check-label" for="inlineCheckbox2">Grade 10</label>
                 </div>
                 <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="ageGroup" id="inlineCheckbox3"
+                    <input class="form-check-input" type="radio" name="ageGroup-2" id="inlineCheckbox3"
                         value="Grade 11">
                     <label class="form-check-label" for="inlineCheckbox3">Grade 11</label>
                 </div>
                 <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="ageGroup" id="inlineCheckbox4"
+                    <input class="form-check-input" type="radio" name="ageGroup-4" id="inlineCheckbox4"
                         value="Grade 12">
                     <label class="form-check-label" for="inlineCheckbox4">Grade 12</label>
                 </div>
                 <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="ageGroup" id="inlineCheckbox5"
+                    <input class="form-check-input" type="radio" name="ageGroup-5" id="inlineCheckbox5"
                         value="Freshman">
                     <label class="form-check-label" for="inlineCheckbox5">Freshman</label>
                 </div>
                 <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="ageGroup" id="inlineCheckbox6"
+                    <input class="form-check-input" type="radio" name="ageGroup-6" id="inlineCheckbox6"
                         value="Sophomore">
                     <label class="form-check-label" for="inlineCheckbox6">Sophomore</label>
                 </div>
                 <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="ageGroup" id="inlineCheckbox7"
+                    <input class="form-check-input" type="radio" name="ageGroup-7" id="inlineCheckbox7"
                         value="Junior">
                     <label class="form-check-label" for="inlineCheckbox7">Junior</label>
                 </div>
                 <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="ageGroup" id="inlineCheckbox8"
+                    <input class="form-check-input" type="radio" name="ageGroup-8" id="inlineCheckbox8"
                         value="Senior">
                     <label class="form-check-label" for="inlineCheckbox8">Senior</label>
                 </div>
                 <div class="form-check form-check-inline">
-                    <input class="form-check-input" type="radio" name="ageGroup" id="inlineCheckbox9"
+                    <input class="form-check-input" type="radio" name="ageGroup-9" id="inlineCheckbox9"
                         value="Graduate">
                     <label class="form-check-label" for="inlineCheckbox9">Graduate</label>
                 </div>


### PR DESCRIPTION
To enable multi-selects in the add event form we need to be able to store lists within Datastore. There are two ways to do this:
1. Use native array type. This proved difficult to find documentation on. However, arrays are allowed a primitive data type, but there are slight complications in that Java code can only save arrays of `Value` type. This PR gives an example of this using "colors".
2. Use strings. It's easy to store a comma-delimited string like `"A,B,C,D"` then split the string into an array when reading it `"A,B,C,D".split(",") => ["A", "B", "C", "D"]`. The PR gives a backwards-compatible example of this by storing the array-string under `ageGroup`, then adding a `ageGroups[]` field in the GET response. 

Suggest the former since it requires no new knowledge of the Datastore Java API, and thus is much faster to implement.